### PR TITLE
update(vertexlauncher): Add Slang dependency to README under Building…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you build from source, install:
 - Cargo
 - Git
 - a working C/C++ toolchain
+- Slang binaries found from `https://shader-slang.org/tools/`
 
 Windows release artifacts must use the MSVC targets. `windows-gnu` is not part of the supported release matrix.
 


### PR DESCRIPTION
This PR lets the user know that they will need to have Slang installed on their environment in order to successfully build the launcher from source code. 