### PR TITLE
update(vertexlauncher): Add Instruction For Slang Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ If you build from source, install:
 - Cargo
 - Git
 - a working C/C++ toolchain
-- Slang binaries found from `https://shader-slang.org/tools/`
+- Slang binaries found from `https://shader-slang.org/tools/` or `https://github.com/shader-slang/slang/releases`
 
 Windows release artifacts must use the MSVC targets. `windows-gnu` is not part of the supported release matrix.
+
+Be sure to add the Slang binaries to your PATH variable, otherwise the app will not successfully compile and build.
 
 ## Native Linux Prerequisites
 

--- a/crates/launcher_ui/src/ui/top_bar.rs
+++ b/crates/launcher_ui/src/ui/top_bar.rs
@@ -621,8 +621,8 @@ fn render_active_user_terminal_button(
                     };
                     let _ = text_ui.label(
                         ui,
-                        "topbar_user_active_label",
-                        if compact { "active" } else { "user active" },
+                        "topbar_player_active_label",
+                        if compact { "active" } else { "player active" },
                         &label_style,
                     );
                 },


### PR DESCRIPTION
The purpose of this PR is to add a concise instruction concerning the Slang dependency. I also took the liberty of adding the URL of the GitHub repository for Slang. 