### PR TITLE
update(vertexlauncher): Fix Windows Build Error

### DIFF
--- a/crates/launcher_ui/src/window_effects.rs
+++ b/crates/launcher_ui/src/window_effects.rs
@@ -343,7 +343,7 @@ mod windows {
         let blur_behind = DWM_BLURBEHIND {
             dwFlags: DWM_BB_ENABLE,
             fEnable: 1,
-            hRgnBlur: 0,
+            hRgnBlur: std::ptr::null_mut(),
             fTransitionOnMaximized: 0,
         };
         let result = unsafe { DwmEnableBlurBehindWindow(hwnd, &blur_behind) };


### PR DESCRIPTION
This PR fixes an error associated with building the app on Windows. The build will fail if the hRgnBlur variable is set to 0. The parameter needs to be defined as a null pointer in order for the Windows build to compile successfully. 